### PR TITLE
Changed Makefile to be more portable to OpenBSD.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,10 @@
-CC=gcc
 CFLAGS=-Wall -Werror -fpic
 COVER=#--coverage
 
 all: build/libfzf.so
 
 build/libfzf.so: src/fzf.c src/fzf.h
-	mkdir -pv build
+	mkdir -p build
 	$(CC) -O3 $(CFLAGS) -shared src/fzf.c -o build/libfzf.so
 
 build/test: build/libfzf.so test/test.c


### PR DESCRIPTION
This change makes some modifications so that the GNU Make port on
OpenBSD can build this project.

* Removed the `-v` switch from the `mkdir` command..
* Removed the forced setting of CC. GNU Make defaults to
  (`/usr/bin/`)`cc` which is likely a sane default. This allows
  overriding with something like `CC=/path/to/my/compiler gmake`.
  
  Setting `CC` in the Makefile overrides the environment.
  
```bash
ryan telescope-fzf-native.nvim (main)$ head -10 Makefile                                                                                               
CC=gcc                                                                                                                                                 
CFLAGS=-Wall -Werror -fpic                                                                                                                             
COVER=#--coverage                                                                                                                                      
                                                                                                                                                       
all: build/libfzf.so                                                                                                                                   
                                                                                                                                                       
build/libfzf.so: src/fzf.c src/fzf.h                                                                                                                   
        mkdir -p build                                                                                                                                 
                $(CC) -O3 $(CFLAGS) -shared src/fzf.c -o build/libfzf.so                                                                               
```

```bash                                                                                                                                                       
ryan telescope-fzf-native.nvim (main)$ gmake                                                                                                           
mkdir -p build                                                                                                                                         
gcc -O3 -Wall -Werror -fpic -shared src/fzf.c -o build/libfzf.so                                                                                       
gmake: gcc: No such file or directory                                                                                                                  
gmake: *** [Makefile:9: build/libfzf.so] Error 127
```

```bash                                                                                                     
ryan telescope-fzf-native.nvim (main)$ CC=/usr/bin/cc gmake                                                                                            
mkdir -p build                                                                                                                                         
gcc -O3 -Wall -Werror -fpic -shared src/fzf.c -o build/libfzf.so                                                                                       
gmake: gcc: No such file or directory                                                                                                                  
gmake: *** [Makefile:9: build/libfzf.so] Error 127
```

```bash                                                                                                 
ryan telescope-fzf-native.nvim (main)$ /usr/bin/cc --version                                                                                           
OpenBSD clang version 11.1.0                                                                                                                           
Target: amd64-unknown-openbsd6.9                                                                                                                       
Thread model: posix                                                                                                                                    
InstalledDir: /usr/bin
```