### PR TITLE
CMake: build .so rather than .dylib on MacOS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,6 +15,7 @@ if (CMAKE_C_COMPILER_ID STREQUAL "MSVC")
     target_compile_options(${PROJECT_NAME} PRIVATE /W4)
 else ()
     target_compile_options(${PROJECT_NAME} PRIVATE -Wall)
+    set(CMAKE_SHARED_LIBRARY_SUFFIX .so)
 endif ()
 
 install(TARGETS ${PROJECT_NAME} DESTINATION ${CMAKE_BINARY_DIR})


### PR DESCRIPTION
I tried to install on MacOS using the provided shell snippet in the README, but it seems by default CMake builds the library as `libfzf.dylib`, which of course then doesn't load because it expects `libfzf.so`:

```
packer.nvim: Error running config for telescope.nvim: .../start/telescope.nvim/lua/telescope/_extensions/init.lua:10: 'fzf' extension doesn't exist or isn't installed: ...k/packer/start/telescope-fzf-native.nvim/lua
/fzf_lib.lua:11: dlopen(/Users/andrew/.local/share/nvim/site/pack/packer/start/telescope-fzf-native.nvim/lua/../build/libfzf.so, 0x0005): tried: '/Users/andrew/.local/share/nvim/site/pack/packer/start/telescope-fzf-
native.nvim/lua/../build/libfzf.so' (no such file), '/Users/andrew/.local/share/nvim/site/pack/packer/start/telescope-fzf-native.nvim/build/libfzf.so' (no such file)
```

The provided Makefile seems to work fine, and it is easy enough to instruct CMake to build a .so instead on non-Windows platforms, which is what this PR does. Alternatively you could detect the OS in the `fzf_lib.lua` and add an additional branch for MacOS.