### PR TITLE
🔨 Cleanup CMake to remove warnings + fix windows builds + add presets

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,8 +3,6 @@ project(fzf LANGUAGES C)
 
 add_library(${PROJECT_NAME} SHARED "src/fzf.c")
 
-set(is-windows $<STREQUAL:${CMAKE_SYSTEM_NAME},Windows>)
-
 target_include_directories(${PROJECT_NAME} PUBLIC
   $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/src>)
 target_compile_options(${PROJECT_NAME}
@@ -13,18 +11,17 @@ target_compile_options(${PROJECT_NAME}
     $<$<NOT:$<C_COMPILER_ID:MSVC>>:-Wall>)
 target_compile_definitions(${PROJECT_NAME}
   PRIVATE
-    $<${is-windows}:_CRT_NONSTDC_NO_DEPRECATE>
-    $<${is-windows}:_CRT_SECURE_NO_DEPRECATE>
-    $<${is-windows}:_CRT_SECURE_NO_WARNINGS>)
+    $<$<PLATFORM_ID:Windows>:_CRT_NONSTDC_NO_DEPRECATE>
+    $<$<PLATFORM_ID:Windows>:_CRT_SECURE_NO_DEPRECATE>
+    $<$<PLATFORM_ID:Windows>:_CRT_SECURE_NO_WARNINGS>)
 
 set_target_properties(${PROJECT_NAME} PROPERTIES
     WINDOWS_EXPORT_ALL_SYMBOLS ON
     C_STANDARD 99
-    PREFIX lib
-    SUFFIX .so)
+    PREFIX lib)
 
 # This cannot be a generator expression in this version of CMake
-if (CMAKE_SYSTEM_NAME STREQUAL "Windows")
+if (NOT CMAKE_SYSTEM_NAME STREQUAL "Windows")
   set_property(TARGET ${PROJECT_NAME} PROPERTY SUFFIX .so)
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,21 +1,31 @@
 cmake_minimum_required(VERSION 3.2)
-project(fzf C)
+project(fzf LANGUAGES C)
 
 add_library(${PROJECT_NAME} SHARED "src/fzf.c")
 
+set(is-windows $<STREQUAL:${CMAKE_SYSTEM_NAME},Windows>)
+
+target_include_directories(${PROJECT_NAME} PUBLIC
+  $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/src>)
+target_compile_options(${PROJECT_NAME}
+  PRIVATE
+    $<$<C_COMPILER_ID:MSVC>:/W4>
+    $<$<NOT:$<C_COMPILER_ID:MSVC>>:-Wall>)
+target_compile_definitions(${PROJECT_NAME}
+  PRIVATE
+    $<${is-windows}:_CRT_NONSTDC_NO_DEPRECATE>
+    $<${is-windows}:_CRT_SECURE_NO_DEPRECATE>
+    $<${is-windows}:_CRT_SECURE_NO_WARNINGS>)
+
 set_target_properties(${PROJECT_NAME} PROPERTIES
-    PREFIX "lib"
-    C_STANDARD 99
     WINDOWS_EXPORT_ALL_SYMBOLS ON
-)
+    C_STANDARD 99
+    PREFIX lib
+    SUFFIX .so)
 
-target_include_directories(${PROJECT_NAME} PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/src)
-
-if (CMAKE_C_COMPILER_ID STREQUAL "MSVC")
-    target_compile_options(${PROJECT_NAME} PRIVATE /W4)
-else ()
-    target_compile_options(${PROJECT_NAME} PRIVATE -Wall)
-    set(CMAKE_SHARED_LIBRARY_SUFFIX .so)
-endif ()
+# This cannot be a generator expression in this version of CMake
+if (CMAKE_SYSTEM_NAME STREQUAL "Windows")
+  set_property(TARGET ${PROJECT_NAME} PROPERTY SUFFIX .so)
+endif()
 
 install(TARGETS ${PROJECT_NAME} DESTINATION ${CMAKE_BINARY_DIR})

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -1,0 +1,28 @@
+{
+  "version": 1,
+  "cmakeMinimumRequired": {
+    "major": 3,
+    "minor": 19,
+    "patch": 0
+  },
+  "configurePresets": [
+    {
+      "name": "base",
+      "hidden": true,
+      "binaryDir": "${sourceDir}/build",
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "Release"
+      }
+    },
+    {
+      "name": "ninja",
+      "inherits": "base",
+      "generator": "Ninja"
+    },
+    {
+      "name": "make",
+      "inherits": "base",
+      "generator": "Unix Makefiles"
+    }
+  ]
+}


### PR DESCRIPTION
This change brings in several things

1. The `CMakeLists.txt` file has been reorganized and brought up to more "modern" CMake code (while still working with CMake 3.2 at a minimum)
2. A fix has been added for #77, to always set the suffix to `.dll`, regardless of toolchain
3. Warnings for _CRT_SECURE and _CRT_NONSTDC are now disabled.
4. This also adds the most minimal version of a cmake "preset" for CMake 3.19 and later. This adds generators for unix makefiles and ninja, allowing users to simply execute their post-install step as:
   ```console
   $ cmake --preset <ninja|make>
   $ cmake --build build --target install
   ```

Sadly, this couldn't be simplified further unless a hard minimum of CMake 3.20 is set, as that would allow for an install build preset, allowing the steps to turn into `cmake --preset <preset> && cmake --build --preset <preset>`. I've not changed the readme as I'm probably the only one who will end up using the preset approach anyhow.

Closes #77 
