### PR TITLE
Keep line order in non fuzzy mode

### DIFF
--- a/lua/telescope/_extensions/fzf.lua
+++ b/lua/telescope/_extensions/fzf.lua
@@ -97,6 +97,8 @@ local get_fzf_sorter = function(opts)
       local score = fzf.get_score(line, obj, self.state.slab)
       if score == 0 then
         return -1
+      elseif not fuzzy_mode then
+        return 1
       else
         return 1 / score
       end


### PR DESCRIPTION
When we set fuzzy = false it's would be great to keep lines in orders they are appear in file/buffer/source. 
This will mimic grep like behavior. 