### PR TITLE
fix: Makefile is having problems with creating *.dll

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,9 @@
 CFLAGS = -Wall -Werror -fpic -std=gnu99
-CC = gcc
 
 ifeq ($(OS),Windows_NT)
     MKD = cmd //C mkdir
     RM = cmd //C rmdir //Q //S
+	CC = gcc
     TARGET := libfzf.dll
 else
     MKD = mkdir -p

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ CFLAGS = -Wall -Werror -fpic -std=gnu99
 ifeq ($(OS),Windows_NT)
     MKD = cmd //C mkdir
     RM = cmd //C rmdir //Q //S
-	CC = gcc
+    CC = gcc
     TARGET := libfzf.dll
 else
     MKD = mkdir -p

--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,9 @@
 CFLAGS = -Wall -Werror -fpic -std=gnu99
+CC = gcc
 
 ifeq ($(OS),Windows_NT)
-    MKD = cmd /C mkdir
-    RM = cmd /C rmdir /Q /S
-    CC = gcc
+    MKD = cmd //C mkdir
+    RM = cmd //C rmdir //Q //S
     TARGET := libfzf.dll
 else
     MKD = mkdir -p


### PR DESCRIPTION
The switches/parameters for commands needs to be escaped, without it - it shows errors, or doesn't compile properly

fix #82