### PR TITLE
feat: include environment CFLAGS for make

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-CFLAGS = -Wall -Werror -fpic -std=gnu99
+CFLAGS += -Wall -Werror -fpic -std=gnu99
 
 ifeq ($(OS),Windows_NT)
     CC = gcc


### PR DESCRIPTION
This allows the user to pass their own flags. I wanted to pass `-march=native -mtune=native` (the fzf binary runs locally by design, so why not), but the Makefile overrides `CFLAGS`.

With the change, one can easily use e.g. this in nvim:
```lua
build = "CFLAGS='-flag=foo -flag=bar' make"
```

---

With cmake `(…) -DCMAKE_C_FLAGS='-flag=foo -flag=bar' -DCMAKE_BUILD_TYPE=Release (…)` should already work as-is.