### PR TITLE
Add lazy.nvim instructions to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,13 @@ Plug 'nvim-telescope/telescope-fzf-native.nvim', { 'do': 'cmake -S. -Bbuild -DCM
 #### packer.nvim
 
 ```lua
-use {'nvim-telescope/telescope-fzf-native.nvim', run = 'cmake -S. -Bbuild -DCMAKE_BUILD_TYPE=Release && cmake --build build --config Release && cmake --install build --prefix build' }
+use { 'nvim-telescope/telescope-fzf-native.nvim', run = 'cmake -S. -Bbuild -DCMAKE_BUILD_TYPE=Release && cmake --build build --config Release && cmake --install build --prefix build' }
+```
+
+#### lazy.nvim
+
+```lua
+{ 'nvim-telescope/telescope-fzf-native.nvim', build = 'cmake -S. -Bbuild -DCMAKE_BUILD_TYPE=Release && cmake --build build --config Release && cmake --install build --prefix build' }
 ```
 
 ### Make (Linux, MacOS, Windows with MinGW)
@@ -64,7 +70,13 @@ Plug 'nvim-telescope/telescope-fzf-native.nvim', { 'do': 'make' }
 #### packer.nvim
 
 ```lua
-use {'nvim-telescope/telescope-fzf-native.nvim', run = 'make' }
+use { 'nvim-telescope/telescope-fzf-native.nvim', run = 'make' }
+```
+
+#### lazy.nvim
+
+```lua
+{ 'nvim-telescope/telescope-fzf-native.nvim', build = 'make' }
 ```
 
 ## Telescope Setup and Configuration:


### PR DESCRIPTION
I noticed the instructions for installation are missing directions for usage with lazy.nvim. I just had a bit of trouble finding the right syntax for running the build command after installation. Thus I thought I might just as well add it here.