### PR TITLE
add zigcc-based cmake toolchains and presets for cross-compilation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,8 @@
 cmake_minimum_required(VERSION 3.2)
 project(fzf LANGUAGES C)
 
+set(ENABLE_TESTING FALSE CACHE BOOL "Build unit tests for this project")
+
 add_library(${PROJECT_NAME} SHARED "src/fzf.c")
 
 target_include_directories(${PROJECT_NAME} PUBLIC
@@ -26,3 +28,14 @@ if (NOT CMAKE_SYSTEM_NAME STREQUAL "Windows")
 endif()
 
 install(TARGETS ${PROJECT_NAME} DESTINATION ${CMAKE_BINARY_DIR})
+
+if(ENABLE_TESTING)
+  add_library(examiner examiner/src/examiner.c)
+  target_include_directories(examiner PUBLIC examiner/src)
+
+  add_executable(${PROJECT_NAME}_test test/test.c)
+  target_link_libraries(${PROJECT_NAME}_test PRIVATE ${PROJECT_NAME} examiner)
+
+  include(CTest)
+  add_test(NAME ${PROJECT_NAME}_test COMMAND ${PROJECT_NAME}_test)
+endif()

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -1,10 +1,17 @@
 {
-  "version": 1,
+  "version": 6,
   "cmakeMinimumRequired": {
     "major": 3,
     "minor": 19,
     "patch": 0
   },
+  "include": [
+    "cmake/presets/x86_64-linux-gnu.json",
+    "cmake/presets/x86_64-linux-musl.json",
+    "cmake/presets/aarch64-linux-gnu.json",
+    "cmake/presets/aarch64-macos-none.json",
+    "cmake/presets/x86_64-windows-gnu.json"
+  ],
   "configurePresets": [
     {
       "name": "base",

--- a/cmake/presets/aarch64-linux-gnu.json
+++ b/cmake/presets/aarch64-linux-gnu.json
@@ -1,0 +1,41 @@
+{
+  "version": 6,
+  "cmakeMinimumRequired": {
+    "major": 3,
+    "minor": 19,
+    "patch": 0
+  },
+  "configurePresets": [
+    {
+      "name": "aarch64-linux-gnu",
+      "hidden": false,
+      "binaryDir": "${sourceDir}/build",
+      "toolchainFile": "cmake/toolchains/aarch64-linux-gnu.cmake",
+      "cacheVariables": {
+        "CMAKE_POSITION_INDEPENDENT_CODE": "ON",
+        "CMAKE_BUILD_TYPE": "Release"
+      }
+    }
+  ],
+  "buildPresets": [
+    {
+      "name": "aarch64-linux-gnu",
+      "configurePreset": "aarch64-linux-gnu"
+    }
+  ],
+  "workflowPresets": [
+    {
+      "name": "aarch64-linux-gnu",
+      "steps": [
+        {
+          "type": "configure",
+          "name": "aarch64-linux-gnu"
+        },
+        {
+          "type": "build",
+          "name": "aarch64-linux-gnu"
+        }
+      ]
+    }
+  ]
+}

--- a/cmake/presets/aarch64-macos-none.json
+++ b/cmake/presets/aarch64-macos-none.json
@@ -1,0 +1,41 @@
+{
+  "version": 6,
+  "cmakeMinimumRequired": {
+    "major": 3,
+    "minor": 19,
+    "patch": 0
+  },
+  "configurePresets": [
+    {
+      "name": "aarch64-macos-none",
+      "hidden": false,
+      "binaryDir": "${sourceDir}/build",
+      "toolchainFile": "cmake/toolchains/aarch64-macos-none.cmake",
+      "cacheVariables": {
+        "CMAKE_POSITION_INDEPENDENT_CODE": "ON",
+        "CMAKE_BUILD_TYPE": "Release"
+      }
+    }
+  ],
+  "buildPresets": [
+    {
+      "name": "aarch64-macos-none",
+      "configurePreset": "aarch64-macos-none"
+    }
+  ],
+  "workflowPresets": [
+    {
+      "name": "aarch64-macos-none",
+      "steps": [
+        {
+          "type": "configure",
+          "name": "aarch64-macos-none"
+        },
+        {
+          "type": "build",
+          "name": "aarch64-macos-none"
+        }
+      ]
+    }
+  ]
+}

--- a/cmake/presets/x86_64-linux-gnu.json
+++ b/cmake/presets/x86_64-linux-gnu.json
@@ -1,0 +1,41 @@
+{
+  "version": 6,
+  "cmakeMinimumRequired": {
+    "major": 3,
+    "minor": 19,
+    "patch": 0
+  },
+  "configurePresets": [
+    {
+      "name": "x86_64-linux-gnu",
+      "hidden": false,
+      "binaryDir": "${sourceDir}/build",
+      "toolchainFile": "cmake/toolchains/x86_64-linux-gnu.cmake",
+      "cacheVariables": {
+        "CMAKE_POSITION_INDEPENDENT_CODE": "ON",
+        "CMAKE_BUILD_TYPE": "Release"
+      }
+    }
+  ],
+  "buildPresets": [
+    {
+      "name": "x86_64-linux-gnu",
+      "configurePreset": "x86_64-linux-gnu"
+    }
+  ],
+  "workflowPresets": [
+    {
+      "name": "x86_64-linux-gnu",
+      "steps": [
+        {
+          "type": "configure",
+          "name": "x86_64-linux-gnu"
+        },
+        {
+          "type": "build",
+          "name": "x86_64-linux-gnu"
+        }
+      ]
+    }
+  ]
+}

--- a/cmake/presets/x86_64-linux-musl.json
+++ b/cmake/presets/x86_64-linux-musl.json
@@ -1,0 +1,41 @@
+{
+  "version": 6,
+  "cmakeMinimumRequired": {
+    "major": 3,
+    "minor": 19,
+    "patch": 0
+  },
+  "configurePresets": [
+    {
+      "name": "x86_64-linux-musl",
+      "hidden": false,
+      "binaryDir": "${sourceDir}/build",
+      "toolchainFile": "cmake/toolchains/x86_64-linux-musl.cmake",
+      "cacheVariables": {
+        "CMAKE_POSITION_INDEPENDENT_CODE": "ON",
+        "CMAKE_BUILD_TYPE": "Release"
+      }
+    }
+  ],
+  "buildPresets": [
+    {
+      "name": "x86_64-linux-musl",
+      "configurePreset": "x86_64-linux-musl"
+    }
+  ],
+  "workflowPresets": [
+    {
+      "name": "x86_64-linux-musl",
+      "steps": [
+        {
+          "type": "configure",
+          "name": "x86_64-linux-musl"
+        },
+        {
+          "type": "build",
+          "name": "x86_64-linux-musl"
+        }
+      ]
+    }
+  ]
+}

--- a/cmake/presets/x86_64-windows-gnu.json
+++ b/cmake/presets/x86_64-windows-gnu.json
@@ -1,0 +1,41 @@
+{
+  "version": 6,
+  "cmakeMinimumRequired": {
+    "major": 3,
+    "minor": 19,
+    "patch": 0
+  },
+  "configurePresets": [
+    {
+      "name": "x86_64-windows-gnu",
+      "hidden": false,
+      "binaryDir": "${sourceDir}/build",
+      "toolchainFile": "cmake/toolchains/x86_64-windows-gnu.cmake",
+      "cacheVariables": {
+        "CMAKE_POSITION_INDEPENDENT_CODE": "ON",
+        "CMAKE_BUILD_TYPE": "Release"
+      }
+    }
+  ],
+  "buildPresets": [
+    {
+      "name": "x86_64-windows-gnu",
+      "configurePreset": "x86_64-windows-gnu"
+    }
+  ],
+  "workflowPresets": [
+    {
+      "name": "x86_64-windows-gnu",
+      "steps": [
+        {
+          "type": "configure",
+          "name": "x86_64-windows-gnu"
+        },
+        {
+          "type": "build",
+          "name": "x86_64-windows-gnu"
+        }
+      ]
+    }
+  ]
+}

--- a/cmake/toolchains/aarch64-linux-gnu.cmake
+++ b/cmake/toolchains/aarch64-linux-gnu.cmake
@@ -1,0 +1,9 @@
+set(CMAKE_SYSTEM_NAME "Linux")
+set(CMAKE_SYSTEM_VERSION 1)
+set(CMAKE_SYSTEM_PROCESSOR "aarch64")
+
+set(CMAKE_C_COMPILER "zig" cc -target aarch64-linux-gnu)
+set(CMAKE_CXX_COMPILER "zig" c++ -target aarch64-linux-gnu)
+
+set(CMAKE_AR "${CMAKE_CURRENT_LIST_DIR}/zig-ar.sh")
+set(CMAKE_RANLIB "${CMAKE_CURRENT_LIST_DIR}/zig-ranlib.sh")

--- a/cmake/toolchains/aarch64-macos-none.cmake
+++ b/cmake/toolchains/aarch64-macos-none.cmake
@@ -1,0 +1,9 @@
+set(CMAKE_SYSTEM_NAME "Darwin")
+set(CMAKE_SYSTEM_VERSION 1)
+set(CMAKE_SYSTEM_PROCESSOR "aarch64")
+
+set(CMAKE_C_COMPILER "zig" cc -target aarch64-macos-none)
+set(CMAKE_CXX_COMPILER "zig" c++ -target aarch64-macos-none)
+
+set(CMAKE_AR "${CMAKE_CURRENT_LIST_DIR}/zig-ar.sh")
+set(CMAKE_RANLIB "${CMAKE_CURRENT_LIST_DIR}/zig-ranlib.sh")

--- a/cmake/toolchains/x86_64-linux-gnu.cmake
+++ b/cmake/toolchains/x86_64-linux-gnu.cmake
@@ -1,0 +1,9 @@
+set(CMAKE_SYSTEM_NAME "Linux")
+set(CMAKE_SYSTEM_VERSION 1)
+set(CMAKE_SYSTEM_PROCESSOR "x86_64")
+
+set(CMAKE_C_COMPILER "zig" cc -target x86_64-linux-gnu)
+set(CMAKE_CXX_COMPILER "zig" c++ -target x86_64-linux-gnu)
+
+set(CMAKE_AR "${CMAKE_CURRENT_LIST_DIR}/zig-ar.sh")
+set(CMAKE_RANLIB "${CMAKE_CURRENT_LIST_DIR}/zig-ranlib.sh")

--- a/cmake/toolchains/x86_64-linux-musl.cmake
+++ b/cmake/toolchains/x86_64-linux-musl.cmake
@@ -1,0 +1,9 @@
+set(CMAKE_SYSTEM_NAME "Linux")
+set(CMAKE_SYSTEM_VERSION 1)
+set(CMAKE_SYSTEM_PROCESSOR "x86_64")
+
+set(CMAKE_C_COMPILER "zig" cc -target x86_64-linux-musl)
+set(CMAKE_CXX_COMPILER "zig" c++ -target x86_64-linux-musl)
+
+set(CMAKE_AR "${CMAKE_CURRENT_LIST_DIR}/zig-ar.sh")
+set(CMAKE_RANLIB "${CMAKE_CURRENT_LIST_DIR}/zig-ranlib.sh")

--- a/cmake/toolchains/x86_64-windows-gnu.cmake
+++ b/cmake/toolchains/x86_64-windows-gnu.cmake
@@ -1,0 +1,9 @@
+set(CMAKE_SYSTEM_NAME "Windows")
+set(CMAKE_SYSTEM_VERSION 1)
+set(CMAKE_SYSTEM_PROCESSOR "x86_64")
+
+set(CMAKE_C_COMPILER "zig" cc -target x86_64-windows-gnu)
+set(CMAKE_CXX_COMPILER "zig" c++ -target x86_64-windows-gnu)
+
+set(CMAKE_AR "${CMAKE_CURRENT_LIST_DIR}/zig-ar.sh")
+set(CMAKE_RANLIB "${CMAKE_CURRENT_LIST_DIR}/zig-ranlib.sh")

--- a/cmake/toolchains/zig-ar.sh
+++ b/cmake/toolchains/zig-ar.sh
@@ -1,0 +1,2 @@
+#!/bin/sh
+zig ar "$@"

--- a/cmake/toolchains/zig-ranlib.sh
+++ b/cmake/toolchains/zig-ranlib.sh
@@ -1,0 +1,2 @@
+#!/bin/sh
+zig ranlib "$@"


### PR DESCRIPTION
saw in https://github.com/nvim-telescope/telescope-fzf-native.nvim/pull/93 that people are interested in this topic so I decided to add it. 

It can be used like this:
```bash
$ cmake --workflow --preset x86_64-windows-gnu
```
`zig` should be in `$PATH`. At least, cross-compiled `libfzf.dll` passes `make ntest` checks.

To compile unit tests, add `-DENABLE_TESTING` cmake option. In this case, it's assumed that examiner is cloned into `examiner` subdirectory. Also, you might want to check this PR: https://github.com/Conni2461/examiner/pull/1