### PR TITLE
Fixed OS detection logic to allow compiling with MYSYS cmake on Windows

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,7 +21,7 @@ set_target_properties(${PROJECT_NAME} PROPERTIES
     PREFIX lib)
 
 # This cannot be a generator expression in this version of CMake
-if (NOT CMAKE_SYSTEM_NAME STREQUAL "Windows")
+if (NOT (MSVC OR MSYS OR MINGW OR WIN32))
   set_property(TARGET ${PROJECT_NAME} PROPERTY SUFFIX .so)
 endif()
 


### PR DESCRIPTION
This allows to build on Windows using CMake from Mysys Buildchain, since the CMAKE_SYSTEM_NAME will be "MYSYS" instead of Windows in this case.