### PR TITLE
feat: luarocks/rocks.nvim support

### DIFF
--- a/.github/workflows/luarocks.yml
+++ b/.github/workflows/luarocks.yml
@@ -1,0 +1,30 @@
+name: Push to Luarocks
+
+on:
+  push:
+    tags:
+      - '*'
+  release:
+    types:
+      - created
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  luarocks-upload:
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0 # Required to count the commits
+      - name: Get Version
+        run: echo "LUAROCKS_VERSION=$(git describe --abbrev=0 --tags)" >> $GITHUB_ENV
+      - name: LuaRocks Upload
+        uses: nvim-neorocks/luarocks-tag-release@v5
+        env:
+          LUAROCKS_API_KEY: ${{ secrets.LUAROCKS_API_KEY }}
+        with:
+          version: ${{ env.LUAROCKS_VERSION }}
+          dependencies: |
+            telescope.nvim
+          template: .github/workflows/rockspec.template

--- a/.github/workflows/rockspec.template
+++ b/.github/workflows/rockspec.template
@@ -1,0 +1,33 @@
+local git_ref = '$git_ref'
+local modrev = '$modrev'
+local specrev = '$specrev'
+
+local repo_url = '$repo_url'
+
+rockspec_format = '3.0'
+package = '$package'
+version = modrev ..'-'.. specrev
+
+description = {
+  summary = '$summary',
+  labels = $labels,
+  homepage = '$homepage',
+  $license
+}
+
+source = {
+  url = repo_url .. '/archive/' .. git_ref .. '.zip',
+  dir = '$repo_name-' .. '$archive_dir_suffix',
+}
+
+build = {
+  type = 'make',
+  build_pass = false,
+  install_variables = {
+    INST_PREFIX='$(PREFIX)',
+    INST_BINDIR='$(BINDIR)',
+    INST_LIBDIR='$(LIBDIR)',
+    INST_LUADIR='$(LUADIR)',
+    INST_CONFDIR='$(CONFDIR)',
+  },
+}

--- a/Makefile
+++ b/Makefile
@@ -44,3 +44,9 @@ clangdhappy:
 
 clean:
 	$(RM) build
+
+install:
+	mkdir -p $(INST_LUADIR)
+	mkdir -p $(INST_LIBDIR)
+	cp -r lua/* $(INST_LUADIR)
+	cp -r build/* $(INST_LIBDIR)

--- a/lua/fzf_lib.lua
+++ b/lua/fzf_lib.lua
@@ -1,6 +1,11 @@
 local ffi = require "ffi"
 
 local library_path = (function()
+  local libfzf_path = package.searchpath("libfzf", package.cpath)
+  if libfzf_path then
+    -- package has been installed with luarocks
+    return library_path
+  end
   local dirname = string.sub(debug.getinfo(1).source, 2, #"/fzf_lib.lua" * -1)
   if package.config:sub(1, 1) == "\\" then
     return dirname .. "../build/libfzf.dll"

--- a/telescope-fzf-native.nvim-scm-1.rockspec
+++ b/telescope-fzf-native.nvim-scm-1.rockspec
@@ -1,0 +1,43 @@
+local MODREV, SPECREV = 'scm', '-1'
+rockspec_format = '3.0'
+package = 'telescope-fzf-native.nvim'
+version = MODREV .. SPECREV
+
+description = {
+  summary = 'FZF sorter for telescope written in c',
+  detailed = [[
+fzf-native is a c port of fzf.
+It only covers the algorithm and implements few functions to support calculating the score.
+]],
+  labels = { 'neovim', 'plugin', },
+  homepage = 'https://github.com/nvim-telescope/telescope-fzf-native.nvim',
+  license = 'MIT',
+}
+
+dependencies = {
+  'lua == 5.1',
+  'telescope.nvim',
+}
+
+source = {
+  url = 'https://github.com/nvim-telescope/telescope-fzf-native.nvim/archive/refs/tags/' .. MODREV .. '.zip',
+  dir = 'telescope-fzf-native.nvim-' .. MODREV
+}
+
+if MODREV == 'scm' then
+  source = {
+    url = 'git://github.com/nvim-telescope/telescope.nvim',
+  }
+end
+
+build = {
+  type = 'make',
+  build_pass = false,
+  install_variables = {
+    INST_PREFIX='$(PREFIX)',
+    INST_BINDIR='$(BINDIR)',
+    INST_LIBDIR='$(LIBDIR)',
+    INST_LUADIR='$(LUADIR)',
+    INST_CONFDIR='$(CONFDIR)',
+  },
+}


### PR DESCRIPTION
Hey again :wave: 

This PR makes this plugin compatible with luarocks, and adds the luarocks-tag-release workflow, for automatically publishing tagged releases.

See also: https://github.com/nvim-telescope/telescope.nvim/pull/2276

@Conni2461 I see this plugin doesn't have any semver tags.
Not sure if you are willing to start maintaining them (manually or automated)?
An alternative would be to just upload the `scm` rockspec (but that would take away the ability to pin installations).

I've tested this locally with the scm rockspec (`luarocks make`).