### PR TITLE
fix: Windows Makefile-based builds cannot create DLL correctly

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,8 +5,8 @@ ifeq ($(OS),Windows_NT)
     TARGET := libfzf.dll
 ifeq (,$(findstring MSYS,$(MSYSTEM)))
 	# On Windows, but NOT msys
-    MKD = cmd /C mkdir
-    RM = cmd /C rmdir /Q /S
+    MKD = cmd //C mkdir
+    RM = cmd //C rmdir //Q //S
 else
     MKD = mkdir -p
     RM = rm -rf


### PR DESCRIPTION
As outlined in #101, the removal of the double slashes for Windows  commands broke Makefile-based builds on Windows. This was originally fixed in #87, but the fix was removed (and re-broken) in #89.