### PR TITLE
fix: Build failed on msys2 windows #126

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,8 +3,8 @@ CFLAGS += -Wall -Werror -fpic -std=gnu99
 ifeq ($(OS),Windows_NT)
     CC = gcc
     TARGET := libfzf.dll
-ifeq (,$(findstring MSYS,$(MSYSTEM)))
-	# On Windows, but NOT msys
+ifeq (,$(findstring $(MSYSTEM),MSYS UCRT64 CLANG64 CLANGARM64 CLANG32 MINGW64 MINGW32))
+	# On Windows, but NOT msys/msys2
     MKD = cmd /C mkdir
     RM = cmd /C rmdir /Q /S
 else


### PR DESCRIPTION
This PR is for #126 ("Build failed on msys2 windows").

### Tested

`make clean ; make`

- MSYS2 (MSYS, UCRT64, CLANG32, CLANG64, MINGW32, MINGW64)
  - Windows 11 (23H2)
  - GNU Make 4.4.1
  - gcc 13.3.0 on MSYS
  - gcc (Rev2, Built by MSYS2 project) 14.2.0 on UCRT64, MINGW32, MINGW64
  - clang 19.1.4 with gcc compat on CLANG32, CLANG64
- WSL2 (Ubuntu 24.04.1 LTS)
  - Windows 11 (23H2)
  - GNU Make 4.3
  - gcc (Ubuntu 13.2.0-23ubuntu4) 13.2.0

### Not tested
- MSYS2 (CLANGARM64)