### PR TITLE
Update license to include Junegunn

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,7 @@
-MIT License
+The MIT License (MIT)
 
-Copyright (c) 2021 Simon Hauser
+Copyright (c) 2013-2024 Junegunn Choi
+Copyright (c) 2021-2025 Simon Hauser
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal
@@ -9,13 +10,13 @@ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 copies of the Software, and to permit persons to whom the Software is
 furnished to do so, subject to the following conditions:
 
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
 
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
 AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.


### PR DESCRIPTION
Hi,  I had created a pull request to Windows Terminal to add a fuzzy finder that used this library and they had done some research and found that it couldn't be brought in because it did not include the original copyright text from the fzf license.

https://github.com/microsoft/terminal/pull/16586#issuecomment-2148033374
https://softwareengineering.stackexchange.com/a/386584

I don't think my pull request will be merged but I figured it would be worth checking to see if the license could be added in case anyone else runs into this.

The pr adds Copyright (c) 2013-2024 Junegunn Choi, and then a couple of other words in the boilerplate did not match the fzf one.  I don't know how important those lines are but from what I could tell it was better to try to match the original license.
