### PR TITLE
Add correct libfzf build commands for Windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,9 @@ use { 'nvim-telescope/telescope-fzf-native.nvim', run = 'cmake -S. -Bbuild -DCMA
 { 'nvim-telescope/telescope-fzf-native.nvim', build = 'cmake -S. -Bbuild -DCMAKE_BUILD_TYPE=Release && cmake --build build --config Release' }
 ```
 
+> **Note:* On Windows you want to replace the `do`, `run`, and `build` command with `cmake -S. -Bbuild -DCMAKE_BUILD_TYPE=Release && cmake --build build --config Release && cmake --install build --prefix build`.
+> This makes sure the libfzf.dll ends up in the correct directory.
+
 ### Make (Linux, MacOS, Windows with MinGW)
 
 This requires `gcc` or `clang` and `make`


### PR DESCRIPTION
On Windows when using CMake and MSVC the binaries end up in a Release folder. To put the binaries in the correct folder running a install step is required.

Fixes: #118