### PR TITLE
CMake: Set minimum required version to 3.10

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.2)
+cmake_minimum_required(VERSION 3.10)
 project(fzf LANGUAGES C)
 
 add_library(${PROJECT_NAME} SHARED "src/fzf.c")


### PR DESCRIPTION
Support for CMake 3.5 was dropped from recent versions of CMake (4.0.0). At least 3.10 might be required by future versions. 

CMake 3.10 was released 2017. I think its fair to require that.