### PR TITLE
chore: bump minimum cmake version to 3.5 so that cmake 4.0 works out of the box.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.2)
+cmake_minimum_required(VERSION 3.5)
 project(fzf LANGUAGES C)
 
 add_library(${PROJECT_NAME} SHARED "src/fzf.c")

--- a/README.md
+++ b/README.md
@@ -57,6 +57,18 @@ use { 'nvim-telescope/telescope-fzf-native.nvim', run = 'cmake -S. -Bbuild -DCMA
 { 'nvim-telescope/telescope-fzf-native.nvim', build = 'cmake -S. -Bbuild -DCMAKE_BUILD_TYPE=Release && cmake --build build --config Release' }
 ```
 
+#### Older Versions of CMake
+
+If your system does not have access to CMake 3.5 or later, then you will need
+to specify an extra flag overriding that minimum version:
+
+```bash
+cmake -S. -Bbuild -DCMAKE_POLICY_VERSION_MINIMUM=<YOUR VERSION HERE> \
+    -DCMAKE_BUILD_TYPE=Release && cmake --build build --config Release
+```
+
+This is not guaranteed to work.
+
 ### Make (Linux, MacOS, Windows with MinGW)
 
 This requires `gcc` or `clang` and `make`


### PR DESCRIPTION
cmake 4.0 dropped support for versions <3.5. Since 3.5 was released in 2016, seems reasonable to bump the required version from 3.2 to 3.5