### PR TITLE
introduce a build.zig

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,6 @@
 build/
 .cache/
+.zig-cache/
+zig-out/
 
 compile_commands.json

--- a/README.md
+++ b/README.md
@@ -79,6 +79,28 @@ use { 'nvim-telescope/telescope-fzf-native.nvim', run = 'make' }
 { 'nvim-telescope/telescope-fzf-native.nvim', build = 'make' }
 ```
 
+### Zig (Linux, Macos, Windows)
+
+This requires `zig`
+
+#### vim-plug
+
+```viml
+Plug 'nvim-telescope/telescope-fzf-native.nvim', { 'do': 'zig build' }
+```
+
+#### packer.nvim
+
+```lua
+use { 'nvim-telescope/telescope-fzf-native.nvim', run = 'zig build' }
+```
+
+#### lazy.nvim
+
+```lua
+{ 'nvim-telescope/telescope-fzf-native.nvim', build = 'zig build' }
+```
+
 ## Telescope Setup and Configuration
 
 ```lua

--- a/build.zig
+++ b/build.zig
@@ -30,6 +30,8 @@ pub fn build(b: *std.Build) void {
 
     const install = b.addInstallArtifact(fzf_lib, .{
         .dest_dir = .{ .override = .{ .custom = "../build" } },
+        .pdb_dir = .disabled,
+        .implib_dir = .disabled,
     });
     b.default_step.dependOn(&install.step);
 }

--- a/build.zig
+++ b/build.zig
@@ -1,0 +1,35 @@
+const std = @import("std");
+
+pub fn build(b: *std.Build) void {
+    const target = b.standardTargetOptions(.{});
+    const optimize = b.standardOptimizeOption(.{ .preferred_optimize_mode = .ReleaseFast });
+
+    const fzf_mod = b.createModule(.{
+        .target = target,
+        .optimize = optimize,
+        .link_libc = true,
+    });
+
+    fzf_mod.addCSourceFile(.{
+        .file = b.path("src/fzf.c"),
+        .language = .c,
+        .flags = &.{
+            "-std=gnu99",
+            "-Wall",
+            "-fpic",
+        },
+    });
+
+    const fzf_lib = b.addLibrary(.{
+        .name = "libfzf",
+        .root_module = fzf_mod,
+        .linkage = .dynamic,
+        .use_llvm = true,
+        .use_lld = true,
+    });
+
+    const install = b.addInstallArtifact(fzf_lib, .{
+        .dest_dir = .{ .override = .{ .custom = "../build" } },
+    });
+    b.default_step.dependOn(&install.step);
+}

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,0 +1,22 @@
+.{
+    .name = .telescope_fzf_native,
+    .version = "0.0.0",
+    .fingerprint = 0x3245da685ca21781,
+    // .minimum_zig_version = "0.16.0",
+    .dependencies = .{},
+    .paths = .{
+        "build.zig",
+        "build.zig.zon",
+        "lua",
+        "src",
+        "test",
+        ".clang-format",
+        ".luacheckrc",
+        ".stylua.toml",
+        "CMakeLists.txt",
+        "CMakePrests.json",
+        "LICENSE",
+        "Makefile",
+        "README.md",
+    },
+}


### PR DESCRIPTION
I added a `build.zig` (and by extension `build.zig.zon`) since on my current windows machine i don't have (C)Make nor a C compiler installed. Since zig bundles together Clang it can be easily used to build on windows (as well as on linux and mac).

(Currently it produces an extra `.lib` file, along side the actual `dll` which is in the correct spot) 